### PR TITLE
the backup_snapshot.yml does not unmount a backup device

### DIFF
--- a/playbooks/book2/backup_snapshot.yml
+++ b/playbooks/book2/backup_snapshot.yml
@@ -46,7 +46,7 @@
       src: "{{ backup_dev }}"
       fstype: ext4
       opts: rw
-      state: mounted
+      state: unmounted
     tags: backup
   - name: remove snapshot
     command: lvremove -f "{{ snapshot_dev }}"


### PR DESCRIPTION
The state parameter in the umount backup section was modified to "unmounted"

Closes-Bug: #6
