### PR TITLE
Fix create_sample_vm.yml have to execute by python interpreter in virtualenv

### DIFF
--- a/playbooks/book1/create_sample_vm.yml
+++ b/playbooks/book1/create_sample_vm.yml
@@ -6,6 +6,7 @@
 - hosts: localhost
 
   vars:
+    ansible_python_interpreter: "{{ lookup('pipe', 'which python') }}"
     auth:
       url: "{{ lookup('env', 'OS_AUTH_URL') }}"
       region_name: "{{ lookup('env', 'OS_REGION_NAME') }}"


### PR DESCRIPTION
Fix create_sample_vm.yml have to execute by python interpreter in virtualenv

Closes-Bug: #16
